### PR TITLE
Add format=raw option to QEMU startup command to suppress a WARNING message

### DIFF
--- a/z_tools/qemu/Makefile
+++ b/z_tools/qemu/Makefile
@@ -1,6 +1,5 @@
-
 QEMU		= qemu-system-i386
-QEMU_ARGS	= -fda fdimage0.bin
+QEMU_ARGS	= -drive file=fdimage0.bin,if=floppy,index=0,format=raw
 
 default:
 	$(QEMU) $(QEMU_ARGS)


### PR DESCRIPTION
プラットフォームに依らない HariboteOS 開発環境の整備、本当にありがとうございます。私は macOS 上で開発をおこなっていますが、この tolenv のおかげでそこまで苦労することなく macOS 上での HariboteOS の開発環境を整備することができました。

その中で、現在の `z_tools/qemu/Makefile` では QEMU 起動コマンドにイメージのフォーマットが指定されておらず、その結果 `make run` コマンド実行時に以下のような警告メッセージが表示されることに気づきました (実際にはこれは、 `z_tools_linux/qemu/Makefile` が元々そうなっているため、という話かもしれませんが)。

```
$ qemu-system-i386 --version
QEMU emulator version 5.1.0
Copyright (c) 2003-2020 Fabrice Bellard and the QEMU Project developers

$ make run
../z_tools/make -r haribote.img
make[1]: `haribote.img' is up to date.
../z_tools/haritol concat ../z_tools/qemu/fdimage0.bin haribote.img
../z_tools/make -r -C ../z_tools/qemu
qemu-system-i386 -fda fdimage0.bin
WARNING: Image format was not specified for 'fdimage0.bin' and probing guessed raw.
         Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the restrictions.
```

QEMU 自体は正常に起動するため、開発作業においては実害はありませんが、 `make run` の実行のたびに何となく気になってしまうので、警告を表示させないようにしたいと思いました。 `-fda` オプションではイメージのフォーマットを指定することができないので、代わりに `-drive` オプションで `format=raw` を指定することで、この警告メッセージを抑制するのが良いのではないかと考えています。これにより、以下のように QEMU 起動時に警告メッセージが表示されなくなります。

```
$ make run
../z_tools/make -r haribote.img
make[1]: `haribote.img' is up to date.
../z_tools/haritol concat ../z_tools/qemu/fdimage0.bin haribote.img
../z_tools/make -r -C ../z_tools/qemu
qemu-system-i386 -drive file=fdimage0.bin,if=floppy,index=0,format=raw
```
